### PR TITLE
[Suggestion] Small exports for distributed programs

### DIFF
--- a/tdigest.js
+++ b/tdigest.js
@@ -391,10 +391,13 @@ function Distributable() {
     Digest.call(this, { mode: 'auto', thresh: 25, delta: 0.2 });
 }
 Distributable.prototype = Object.create(Digest.prototype);
+function round1 (n) {
+    return (Math.round(n * 10)) / 10
+};
 Distributable.prototype.toList = function() {
     var result = [];
     this._cumulate(true); // be sure cumns are exact
-    this.centroids.each(function(c) { result.push([c.mean, c.n]); });
+    this.centroids.each(function(c) { result.push([round1(c.mean), c.n]); });
     return result;
 };
 

--- a/tdigest.js
+++ b/tdigest.js
@@ -352,8 +352,8 @@ function Digest(config) {
 Digest.prototype = Object.create(TDigest.prototype);
 Digest.prototype.constructor = Digest;
 
-Digest.prototype.push = function(x_or_xlist) {
-    TDigest.prototype.push.call(this, x_or_xlist);
+Digest.prototype.push = function(x_or_xlist, n) {
+    TDigest.prototype.push.call(this, x_or_xlist, n);
     this.check_continuous();
 };
 
@@ -387,7 +387,19 @@ Digest.prototype.check_continuous = function() {
     return false;
 };
 
+function Distributable() {
+    Digest.call(this, { mode: 'auto', thresh: 25, delta: 0.2 });
+}
+Distributable.prototype = Object.create(Digest.prototype);
+Distributable.prototype.toList = function() {
+    var result = [];
+    this._cumulate(true); // be sure cumns are exact
+    this.centroids.each(function(c) { result.push([c.mean, c.n]); });
+    return result;
+};
+
 module.exports = {
     'TDigest': TDigest,
-    'Digest': Digest
+    'Digest': Digest,
+    'Distributable': Distributable
 };


### PR DESCRIPTION
Hi,

This is a fork used in large distributed programs where I work. It adds a `Distributable` class that inherits from `Digest`. The purpose of that class is to minimize the size of the exported state (`toArray`) so that a node wanting to read a percentile value can fetch lots of small internal states from each node and recompute the percentile quickly.

It implements `toList()`, which is a more compact version of `toArray()`. It uses arrays to save space on the countless `mean: ..., n: ...`. The centroids can be pushed back into a new Distributable instance using `.push(centroid[0], centroid[1])`.

I have no idea if this would be useful to you or anyone else, but I'm opening this PR in case you find it interesting and/or want to merge it.
