### PR TITLE
Upgrade bintrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/welch/tdigest",
   "dependencies": {
-    "bintrees": "1.0.1"
+    "bintrees": "1.0.2"
   },
   "devDependencies": {
     "better-assert": "^1.0.2",


### PR DESCRIPTION
The bintrees@1.0.1 package doesn't include full license text in the distribution. Transitively, tdigest is affected, because its dependency isn't properly licensed. bintrees@1.0.2 solves the issue. In some enterprise environments, missing full license text in the distribution complicates usage of the package as a dependency, especially given the MIT license itself mentions "The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software."

After merging this, a new patch version of tdigest should be released.