### PR TITLE
[BUG FIX] Continuous centroid sometimes set to string

### DIFF
--- a/tdigest.js
+++ b/tdigest.js
@@ -145,7 +145,7 @@ TDigest.prototype._new_centroid = function(x, n, cumn) {
     // create and insert a new centroid into the digest (don't update
     // cumulatives).
     //
-    var c = {mean:x, n:n, cumn:cumn};
+    var c = {mean:parseFloat(x), n:n, cumn:cumn};
     this.centroids.insert(c);
     this.n += n;
     return c;

--- a/tdigest.js
+++ b/tdigest.js
@@ -145,7 +145,13 @@ TDigest.prototype._new_centroid = function(x, n, cumn) {
     // create and insert a new centroid into the digest (don't update
     // cumulatives).
     //
-    var c = {mean:parseFloat(x), n:n, cumn:cumn};
+    let c;
+    if (this.discrete) { // The mean could be a string
+        c = {mean:x, n:n, cumn:cumn};
+    } else { // Value is always a float for continuous data
+        c = {mean:parseFloat(x), n:n, cumn:cumn};
+    }
+
     this.centroids.insert(c);
     this.n += n;
     return c;


### PR DESCRIPTION
While processing a large data set (attached) the percentile calculations return an equation string.

By casting the centroid mean to a string we can prevent this issue.

![screen shot 2018-12-05 at 15 42 53](https://user-images.githubusercontent.com/9321260/49525679-314a1b80-f8a6-11e8-96d5-b371c189b98c.png)


Dataset: [my_set.csv.zip](https://github.com/welch/tdigest/files/2649517/my_set.csv.zip)

Test Code:

```
const TDigest = require('./tdigest.js').TDigest;
const csv = require('csv-parser');
const fs = require('fs');

const results = [];

let tdigest = new TDigest();

fs.createReadStream('/Users/dominichauton/Desktop/my_set.csv')
    .pipe(csv())
    .on('data', function(x){
        let value = x['change rate'];
        tdigest.push(value);
        // tdigest.compress()
    })
    .on('end', () => {
        tdigest.compress();
        console.log(tdigest.summary());
        // console.log("P50 ~ "+tdigest.percentile(0.5));
        // console.log("P80 ~ "+tdigest.percentile(0.8));
        // console.log("P90 ~ "+tdigest.percentile(0.9));
        // console.log("P99 ~ "+tdigest.percentile(0.99));
        // console.log("P999 ~ "+tdigest.percentile(0.999));
    });
```

Result pre-fix:
```
approximating 199999 samples using 695 centroids
min = 1012878967
Q1  = 3147195358.4957838
Q2  = 396488133-394579145.32856387
Q3  = 497638555-249710228.21663383
max = 999859484
```

Result post-fix:
```
approximating 695 samples using 695 centroids
min = 3
Q1  = 469536336
Q2  = 999859484
Q3  = 1539650282
max = 2628793125
```

